### PR TITLE
お絵描き機能を最低限実装

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -6,15 +6,6 @@ gem 'rails', '~> 6.1.7'
 gem 'mysql2', '~> 0.5'
 gem 'puma', '~> 5.0'
 
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.7'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
@@ -24,6 +15,9 @@ gem 'rack-cors'
 # ログイン機能
 gem 'devise'
 gem 'devise_token_auth'
+
+# 画像アップロード機能を実装
+gem 'carrierwave', '~> 2.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -68,6 +68,14 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    carrierwave (2.2.3)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      mini_mime (>= 0.1.3)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     devise (4.8.1)
@@ -96,6 +104,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     json (2.6.2)
     launchy (2.5.0)
       addressable (~> 2.7)
@@ -116,6 +127,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.16.3)
@@ -213,6 +225,8 @@ GEM
     rubocop-rspec (2.15.0)
       rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     spring (4.1.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
@@ -221,6 +235,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.1)
     thor (1.2.1)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -239,6 +254,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
+  carrierwave (~> 2.0)
   devise
   devise_token_auth
   dotenv-rails

--- a/api/app/controllers/api/v1/pictures_controller.rb
+++ b/api/app/controllers/api/v1/pictures_controller.rb
@@ -12,8 +12,7 @@ class Api::V1::PicturesController < ApplicationController
   end
 
   def create
-    # user_idとの紐付けはどのようにして行うべきか要検討
-    picture = Picture.new(picture_params)
+    picture = current_api_v1_user.pictures.build(picture_params)
     if picture.save
       render json: picture
     else
@@ -38,6 +37,6 @@ class Api::V1::PicturesController < ApplicationController
   end
 
   def picture_params
-    params.require(:pictures).permit(:image, :user_id, :theme_id)
+    params.require(:pictures).permit(:image, :theme_id)
   end
 end

--- a/api/app/controllers/api/v1/pictures_controller.rb
+++ b/api/app/controllers/api/v1/pictures_controller.rb
@@ -37,6 +37,6 @@ class Api::V1::PicturesController < ApplicationController
   end
 
   def picture_params
-    params.require(:pictures).permit(:image, :theme_id)
+    params.require(:picture).permit(:image, :theme_id)
   end
 end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
 
-  skip_before_action :verify_authenticity_token, if: :devise_controller?, raise: false
+  skip_before_action :verify_authenticity_token
   helper_method :current_user, :user_signed_in?
 end

--- a/api/app/models/picture.rb
+++ b/api/app/models/picture.rb
@@ -1,4 +1,5 @@
 class Picture < ApplicationRecord
+  mount_uploader :image, ImageUploader
   belongs_to :user
   belongs_to :theme
 

--- a/api/app/models/theme.rb
+++ b/api/app/models/theme.rb
@@ -1,3 +1,5 @@
 class Theme < ApplicationRecord
+  has_many :pictures
+
   validates :title, presence: true
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
+  has_many :pictures
 
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, uniqueness: { case_sensitive: true }

--- a/api/app/uploaders/image_uploader.rb
+++ b/api/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/api/config/application.rb
+++ b/api/config/application.rb
@@ -36,21 +36,5 @@ module Myapp
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-
-    config.session_store :cookie_store, key: '_interslice_session'
-    config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
-    config.middleware.use ActionDispatch::Flash
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        # 今回はRailsのポートが3000番、Reactのポートが8000番にするので、Reactのリクエストを許可するためにlocalhost:3000を設定
-        origins 'localhost:8000'
-        resource '*',
-                 :headers => :any,
-                 # この一文で、渡される、'access-token'、'uid'、'client'というheaders情報を用いてログイン状態を維持する。
-                 :expose => ['access-token', 'expiry', 'token-type', 'uid', 'client'],
-                 :methods => [:get, :post, :options, :delete, :put]
-      end
-    end
   end
 end

--- a/api/db/migrate/20221128101711_create_pictures.rb
+++ b/api/db/migrate/20221128101711_create_pictures.rb
@@ -3,7 +3,7 @@ class CreatePictures < ActiveRecord::Migration[6.1]
     create_table :pictures do |t|
       t.references :user, null: false, foreign_key: true
       t.references :theme, null: false, foreign_key: true
-      t.string :image, null: false
+      t.text :image, null: false
 
       t.timestamps
     end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 2022_11_28_101711) do
   create_table "pictures", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "theme_id", null: false
-    t.string "image", null: false
+    t.text "image", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["theme_id"], name: "index_pictures_on_theme_id"

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -1,7 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+## 確認用にデータをいくつか用意する。
+
+## テーマを３つほど設定する。
+Theme.create(title: "ドラえもん")
+Theme.create(title: "のび太")
+Theme.create(title: "とんかつDJ")

--- a/front/package.json
+++ b/front/package.json
@@ -14,6 +14,7 @@
     "js-cookie": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.40.0",
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.0"

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -7,6 +7,7 @@ import Home from "./components/pages/Home";
 import SignIn from "./components/pages/SignIn";
 import SignUp from "./components/pages/SignUp";
 import Canvas from "./components/pages/Canvas";
+import ThemeIndex from "./components/pages/ThemeIndex";
 
 export const AuthContext = createContext();
 
@@ -68,6 +69,7 @@ function App() {
             <Route path="/signin" element={<SignIn />} />
             <Route path="/" element={<Home />} />
             <Route path="/picture" element={<Canvas />} />
+            <Route path="/themes" element={<ThemeIndex />} />
           </Routes>
         </CommonLayout>
       </Router>

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -37,6 +37,7 @@ function App() {
     handleGetCurrentUser();
   }, [setCurrentUser]);
 
+  // 認証していなかった場合にルーティングを修正するメソッド（一旦コメントアウト）
   // const Private = ({ children }) => {
   //   const navigate = useNavigate();
   //   if (!loading) {

--- a/front/src/components/atoms/buttons/ResetButton.jsx
+++ b/front/src/components/atoms/buttons/ResetButton.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import Button from "@material-ui/core/Button";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles((theme) => ({
+  submitBtn: {
+    marginTop: theme.spacing(2),
+    flexGrow: 1,
+    textTransform: "none"
+  },
+}));
+
+export const ResetButton = (props) => {
+  const classes = useStyles();
+  
+  return (
+    <>
+      <Button
+        variant="contained"
+        size="large"
+        color="default"
+        // disabled={!props.email || !props.password ? true : false}
+        className={classes.submitBtn}
+        onClick={props.resetCanvas}
+      >
+        {props.children}
+      </Button>
+    </>
+  )
+};

--- a/front/src/components/atoms/buttons/UploadButton.jsx
+++ b/front/src/components/atoms/buttons/UploadButton.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import Button from "@material-ui/core/Button";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles((theme) => ({
+  submitBtn: {
+    marginTop: theme.spacing(2),
+    flexGrow: 1,
+    textTransform: "none"
+  },
+}));
+
+export const UploadButton = (props) => {
+  const classes = useStyles();
+  
+  return (
+    <>
+      <Button
+        variant="contained"
+        size="large"
+        color="default"
+        // disabled={!props.email || !props.password ? true : false}
+        className={classes.submitBtn}
+        onClick={props.uploadCanvas}
+      >
+        {props.children}
+      </Button>
+    </>
+  )
+};

--- a/front/src/components/atoms/buttons/UploadButton.jsx
+++ b/front/src/components/atoms/buttons/UploadButton.jsx
@@ -20,7 +20,7 @@ export const UploadButton = (props) => {
         variant="contained"
         size="large"
         color="default"
-        // disabled={!props.email || !props.password ? true : false}
+        disabled={!props.theme ? true : false}
         className={classes.submitBtn}
         onClick={props.uploadCanvas}
       >

--- a/front/src/components/atoms/cards/ThemeCard.jsx
+++ b/front/src/components/atoms/cards/ThemeCard.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import Card from "@material-ui/core/Card";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  card: {
+    padding: theme.spacing(2),
+    maxWidth: 300,
+  }
+}))
+
+const ThemeCard = (props) => {
+  const classes = useStyles();
+  return (
+    <>
+      <Card
+        className={classes.card}
+      >{props.title}</Card>
+    </>
+  )
+}
+
+export default ThemeCard;

--- a/front/src/components/atoms/selectBoxes/SelectBox.jsx
+++ b/front/src/components/atoms/selectBoxes/SelectBox.jsx
@@ -1,0 +1,29 @@
+import { FormControl, Select, InputLabel, MenuItem } from '@material-ui/core';
+import { useState } from 'react';
+
+export const SelectBox = (props) => {
+  const [theme, setTheme] = useState();
+  const handleChange = (e) => {
+    setTheme(e.target.value);
+  }
+
+  return (
+    <>
+      <FormControl fullWidth>
+        <InputLabel>テーマを選んでください</InputLabel>
+        <Select
+          displayEmpty
+          onChange={handleChange}
+          value={theme || ''}
+        >
+          <MenuItem value="" disabled></MenuItem>
+          {
+            props.themes.map((theme) => (
+              <MenuItem value={theme.id} key={theme.id}>{theme.title}</MenuItem>
+            ))
+          }
+        </Select>
+      </FormControl>
+    </>
+  )
+};

--- a/front/src/components/atoms/selectBoxes/SelectBox.jsx
+++ b/front/src/components/atoms/selectBoxes/SelectBox.jsx
@@ -1,20 +1,17 @@
 import { FormControl, Select, InputLabel, MenuItem } from '@material-ui/core';
-import { useState } from 'react';
 
 export const SelectBox = (props) => {
-  const [theme, setTheme] = useState();
-  const handleChange = (e) => {
-    setTheme(e.target.value);
+  const onChange = (e) => {
+    props.setTheme(e.target.value);
   }
-
   return (
     <>
       <FormControl fullWidth>
         <InputLabel>テーマを選んでください</InputLabel>
         <Select
           displayEmpty
-          onChange={handleChange}
-          value={theme || ''}
+          onChange={onChange}
+          value={props.theme || ''}
         >
           <MenuItem value="" disabled></MenuItem>
           {

--- a/front/src/components/layouts/Header.jsx
+++ b/front/src/components/layouts/Header.jsx
@@ -61,12 +61,22 @@ const Header = () => {
     if (!loading) {
       if (isSignedIn) {
         return (
-          <LinkButton
-            onClick={handleSignOut}
-            color={"inherit"}
-          >
-            サインアウト
-          </LinkButton>
+          <>
+            <LinkButton
+              to={"/picture"}
+              color={"inherit"}
+            >キャンバス</LinkButton>
+            <LinkButton
+              to={"/themes"}
+              color={"inherit"}
+            >テーマ一覧</LinkButton>
+            <LinkButton
+              onClick={handleSignOut}
+              color={"inherit"}
+            >
+              サインアウト
+            </LinkButton>
+          </>
         )
       } else {
         return (
@@ -108,7 +118,7 @@ const Header = () => {
             variant="h6"
             className={classes.title}
           >
-            画伯（仮）
+            画伯かもしれん。
           </Typography>
           <AuthButtons />
         </Toolbar>

--- a/front/src/components/pages/Canvas.jsx
+++ b/front/src/components/pages/Canvas.jsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from "react";
+// import { createPicture } from "../../lib/api/pictures";
+import { ResetButton } from "../atoms/buttons/ResetButton";
+// import { UploadButton } from "../atoms/buttons/UploadButton";
 
 const Canvas = () => {
   const [drawFlag, setDrawFlag] = useState(0);
+  const [drawJudgement, setDrawJudgement] = useState(0);
+  const bgColor = 'rgb(255,255,255)';
   let canvas;
   let ctx;
   let Xpoint, Ypoint;
@@ -34,6 +39,7 @@ const Canvas = () => {
       Xpoint = e.clientX - rect.left;
       Ypoint = e.clientY - rect.top;
       setDrawFlag(1);
+      setDrawJudgement(1);
       ctx.lineTo(Xpoint, Ypoint);
       ctx.lineCap = "round";
       ctx.strokeStyle = x;
@@ -79,7 +85,49 @@ const Canvas = () => {
     }
   }
 
+  const resetCanvas = () => {
+    if (window.confirm('本当にリセットしますか？')) {
+      setDrawJudgement(0);
+      ctx.fillStyle = bgColor;
+      ctx.clearRect(0, 0, ctx.canvas.clientWidth, ctx.canvas.clientHeight);
+    }
+  }
 
+  // 描いた絵をアップロードする機能を実装（無限レンダリングされてるっぽいので一旦コメントアウト）
+  // const createPicture = () => {
+  //   if (drawJudgement === 0) {
+  //     window.alert('何か記入してください');
+  //   } else {
+  //     canvas.toBlob((blob) => {
+  //       let reader = new FileReader();
+  //       // CSRFトークンを発行（おそらくここの取得はできていない。一旦コメントアウト）
+  //       // const token = document.getElementsByName("csrf-token")[0].content;
+  //       reader.readAsDataURL(blob);
+
+  //       reader.onload = async (e) => {
+  //         e.preventDefault();
+  //         let dataUrlBase64 = reader.result;
+  //         let base64 = dataUrlBase64.replace(/data:.*\/.*;base64,/, '');
+  //         const data = {
+  //           image: base64
+  //         }
+  //         // エラー回避のメソッドを実行。適切に実行されるかを確認する。
+  //         try {
+  //           // 確認用コンソール出力です。実装できたら消してください。
+  //           console.log("ここだ！");
+  //           const res = await createPicture(data);
+  //           if (res.status === 200) {
+  //             // ページ遷移するようにする
+  //             console.log("登録されてるかもね。");
+  //           }
+  //         } catch (e) {
+  //           console.log(e);
+  //         }
+  //       };
+  //     // pngファイルで保存するよう第二引数に設定することができる。 
+  //     }, 'image/png');
+  //   };
+  // };
   
   
   const style = {
@@ -95,6 +143,8 @@ const Canvas = () => {
   return (
     <>
       <canvas id="canvas" width="700" height="500" style={style}></canvas>
+      <ResetButton resetCanvas={resetCanvas}>キャンバスをリセットする</ResetButton>
+      {/* <UploadButton uploadCanvas={createPicture}>画像をアップロード</UploadButton> */}
     </>
   )
 }

--- a/front/src/components/pages/Canvas.jsx
+++ b/front/src/components/pages/Canvas.jsx
@@ -1,17 +1,32 @@
 import React, { useEffect, useState } from "react";
-// import { createPicture } from "../../lib/api/pictures";
+import { createPicture } from "../../lib/api/pictures";
 import { ResetButton } from "../atoms/buttons/ResetButton";
-// import { UploadButton } from "../atoms/buttons/UploadButton";
+
+import { Grid } from "@material-ui/core";
+import { UploadButton } from "../atoms/buttons/UploadButton";
+import { SelectBox } from "../atoms/selectBoxes/SelectBox";
+
+import { getThemes } from "../../lib/api/themes";
 
 const Canvas = () => {
   const [drawFlag, setDrawFlag] = useState(0);
-  const [drawJudgement, setDrawJudgement] = useState(0);
+  const [theme, setTheme] = useState();
+  const [themes, setThemes] = useState([]);
+  
   const bgColor = 'rgb(255,255,255)';
   let canvas;
   let ctx;
   let Xpoint, Ypoint;
   let x = "red";
   let y = 2;
+
+  const generateParams = (base64) => {
+    const pictureParams = {
+      image: base64,
+      theme_id: theme,
+    };
+    return pictureParams;
+  };
   
   useEffect(() => {
     canvas = document.getElementById("canvas");
@@ -39,7 +54,6 @@ const Canvas = () => {
       Xpoint = e.clientX - rect.left;
       Ypoint = e.clientY - rect.top;
       setDrawFlag(1);
-      setDrawJudgement(1);
       ctx.lineTo(Xpoint, Ypoint);
       ctx.lineCap = "round";
       ctx.strokeStyle = x;
@@ -87,47 +101,63 @@ const Canvas = () => {
 
   const resetCanvas = () => {
     if (window.confirm('本当にリセットしますか？')) {
-      setDrawJudgement(0);
       ctx.fillStyle = bgColor;
       ctx.clearRect(0, 0, ctx.canvas.clientWidth, ctx.canvas.clientHeight);
     }
   }
 
-  // 描いた絵をアップロードする機能を実装（無限レンダリングされてるっぽいので一旦コメントアウト）
-  // const createPicture = () => {
-  //   if (drawJudgement === 0) {
-  //     window.alert('何か記入してください');
-  //   } else {
-  //     canvas.toBlob((blob) => {
-  //       let reader = new FileReader();
-  //       // CSRFトークンを発行（おそらくここの取得はできていない。一旦コメントアウト）
-  //       // const token = document.getElementsByName("csrf-token")[0].content;
-  //       reader.readAsDataURL(blob);
+  const handleGetThemes = async () => {
+    try {
+      const res = await getThemes();
+      if (res.status === 200) {
+        const data = res.data;
+        setThemes(data);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
 
-  //       reader.onload = async (e) => {
-  //         e.preventDefault();
-  //         let dataUrlBase64 = reader.result;
-  //         let base64 = dataUrlBase64.replace(/data:.*\/.*;base64,/, '');
-  //         const data = {
-  //           image: base64
-  //         }
-  //         // エラー回避のメソッドを実行。適切に実行されるかを確認する。
-  //         try {
-  //           // 確認用コンソール出力です。実装できたら消してください。
-  //           console.log("ここだ！");
-  //           const res = await createPicture(data);
-  //           if (res.status === 200) {
-  //             // ページ遷移するようにする
-  //             console.log("登録されてるかもね。");
-  //           }
-  //         } catch (e) {
-  //           console.log(e);
-  //         }
-  //       };
-  //     // pngファイルで保存するよう第二引数に設定することができる。 
-  //     }, 'image/png');
-  //   };
-  // };
+  useEffect(() => {
+    handleGetThemes();
+  }, []);
+
+  const uploadPicture = () => {
+    if (window.confirm("保存して良いですか？") === true) {
+      canvas.toBlob((blob) => {
+        let reader = new FileReader();
+        // CSRFトークンを発行（おそらくここの取得はできていない。一旦コメントアウト）
+        // const token = document.getElementsByName("csrf-token")[0].content;
+        reader.readAsDataURL(blob);
+
+        reader.onload = async (e) => {
+          e.preventDefault();
+          let dataUrlBase64 = reader.result;
+          const base64 = dataUrlBase64.replace(/data:.*\/.*;base64,/, '');
+          // paramsにしっかり値が入っていない！！（重要！）
+          const params = generateParams(base64);
+          console.log(params);
+          // console.log(image);
+          // console.log(base64.class);
+          // エラー回避のメソッドを実行。適切に実行されるかを確認する。
+          try {
+            const res = await createPicture(params);
+            // 確認用コンソール出力です。実装できたら消してください。
+            console.log("ここだ！");
+            if (res.status === 200) {
+              // ページ遷移するようにする
+              window.alert("登録されてるかもね。");
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        };
+        // pngファイルで保存するよう第二引数に設定することができる。 
+      }, 'image/png');
+      ctx.fillStyle = bgColor;
+      ctx.clearRect(0, 0, ctx.canvas.clientWidth, ctx.canvas.clientHeight);
+    };
+  };
   
   
   const style = {
@@ -142,9 +172,19 @@ const Canvas = () => {
 
   return (
     <>
-      <canvas id="canvas" width="700" height="500" style={style}></canvas>
-      <ResetButton resetCanvas={resetCanvas}>キャンバスをリセットする</ResetButton>
-      {/* <UploadButton uploadCanvas={createPicture}>画像をアップロード</UploadButton> */}
+      <Grid container spacing={3}>
+        <Grid item  xs={9}>
+          <canvas id="canvas" width="700" height="500" style={style}></canvas>
+        </Grid>
+        <Grid item xs={3}>
+          <SelectBox themes={themes} theme={theme} setTheme={setTheme} />
+          <ResetButton resetCanvas={resetCanvas}>キャンバスをリセット</ResetButton>
+          <UploadButton uploadCanvas={uploadPicture} 
+                        theme={theme}>
+                          アップロードする
+                        </UploadButton>
+        </Grid>
+      </Grid>
     </>
   )
 }

--- a/front/src/components/pages/SignIn.jsx
+++ b/front/src/components/pages/SignIn.jsx
@@ -63,6 +63,7 @@ export const SignIn = () => {
     try {
       const res = await signIn(params);
       if (res.status === 200) {
+        console.log(res);
         Cookies.set("_access_token", res.headers["access-token"]);
         Cookies.set("_client", res.headers["client"]);
         Cookies.set("_uid", res.headers["uid"]);

--- a/front/src/components/pages/ThemeIndex.jsx
+++ b/front/src/components/pages/ThemeIndex.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+
+// import { RouteComponentProps, Link } from "react-router-dom";
+
+import Grid from "@material-ui/core/Grid";
+
+import ThemeCard from "../atoms/cards/ThemeCard";
+import { getThemes } from "../../lib/api/themes";
+import { useEffect } from "react";
+
+const ThemeIndex = () => {
+  const [themes, setThemes] = useState([]);
+
+  const handleGetThemes = async () => {
+    try {
+      const res = await getThemes();
+      if (res.status === 200) {
+        const data = res.data;
+        setThemes(data);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  useEffect(() => {
+    handleGetThemes();
+  }, []);
+
+  return (
+    <>
+      <Grid container spacing={3}>
+        {
+          themes.map((theme, index) => (
+            <Grid item xs={4}>
+              <ThemeCard key={index} title={theme.title} />
+            </Grid>
+          ))
+        }
+      </Grid>
+    </>
+  )
+}
+
+export default ThemeIndex;

--- a/front/src/components/pages/ThemeIndex.jsx
+++ b/front/src/components/pages/ThemeIndex.jsx
@@ -31,9 +31,9 @@ const ThemeIndex = () => {
     <>
       <Grid container spacing={3}>
         {
-          themes.map((theme, index) => (
-            <Grid item xs={4}>
-              <ThemeCard key={index} title={theme.title} />
+          themes.map((theme) => (
+            <Grid item xs={4} key={theme.id}>
+              <ThemeCard title={theme.title} />
             </Grid>
           ))
         }

--- a/front/src/lib/api/auth.js
+++ b/front/src/lib/api/auth.js
@@ -22,7 +22,7 @@ export const signOut = () => {
   });
 };
 
-// ログインユーザーの取得
+// 認証済みユーザーの取得
 export const getCurrentUser = () => {
   if (
     !Cookies.get("_access_token") ||
@@ -34,8 +34,8 @@ export const getCurrentUser = () => {
   return client.get("/auth/sessions", {
     headers: {
       "access-token": Cookies.get("_access_token"),
-      client: Cookies.get("_client"),
-      uid: Cookies.get("_uid"),
+      "client": Cookies.get("_client"),
+      "uid": Cookies.get("_uid"),
     },
   });
 };

--- a/front/src/lib/api/pictures.js
+++ b/front/src/lib/api/pictures.js
@@ -1,14 +1,18 @@
 import client from "./client";
-
+import Cookies from "js-cookie";
 
 export const getPictures = () => {
   return client.get("/pictures");
 }
 
-export const createPicture = (data) => {
-  return client.post("/pictures", data);
+export const createPicture = (params) => {
+  return client.post("/pictures", params, { headers: {
+    "access-token": Cookies.get("_access_token"),
+    "client": Cookies.get("_client"),
+    "uid": Cookies.get("_uid"),
+  }});
 }
 
 export const deletePicture = (id) => {
-  return client.delete(`/pictures/${id}`);
+  return client.delete(`/picture/${id}`);
 }

--- a/front/src/lib/api/pictures.js
+++ b/front/src/lib/api/pictures.js
@@ -1,0 +1,14 @@
+import client from "./client";
+
+
+export const getPictures = () => {
+  return client.get("/pictures");
+}
+
+export const createPicture = (data) => {
+  return client.post("/pictures", data);
+}
+
+export const deletePicture = (id) => {
+  return client.delete(`/pictures/${id}`);
+}

--- a/front/src/lib/api/themes.js
+++ b/front/src/lib/api/themes.js
@@ -1,0 +1,10 @@
+import client from "./client";
+
+
+export const getThemes = () => {
+  return client.get("/themes");
+}
+
+export const showTheme = (id) => {
+  return client.get(`/themes/${id}`);
+}

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -7673,6 +7673,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-hook-form@^7.40.0:
+  version "7.40.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.40.0.tgz#62bc939dddca88522cd7f5135b6603192ccf7e17"
+  integrity sha512-0rokdxMPJs0k9bvFtY6dbcSydyNhnZNXCR49jgDr/aR03FDHFOK6gfh8ccqB3fl696Mk7lqh04xdm+agqWXKSw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
### 概要
お絵描き機能と描いた絵を登録できるよう実装した。

### 次やるべきこと
テーマ詳細画面の作成に着手して、そこに絵画が羅列されるようにする！

### 優先度は低いがやるべきこと
今は挙動確認用に`console.log`が至る箇所にあるが、後々整理すること。
リファクタは一旦後でいいと思う。全体像が完成してから`AtomicDesign`に整理して`ESlint`も導入してみる。

### 今後に向けた懸案事項
・バックエンド側はテストを書きながら実装の挙動を確認していく。
・フロントのテストも活用を検討すること。でも、そこには時間をかけすぎず、全体像の完成を最優先させる方向で良い。
・２週間後を目安にデプロイをすること。そのために、ECSのキャッチアップも頑張ること。