### PR TITLE
テーマ一覧・詳細画面をラフに作成

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -21,6 +21,7 @@ gem 'carrierwave', '~> 2.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-rails'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'dotenv-rails'

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     devise (4.8.1)
@@ -141,6 +142,11 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -262,6 +268,7 @@ DEPENDENCIES
   letter_opener_web
   listen (~> 3.3)
   mysql2 (~> 0.5)
+  pry-rails
   puma (~> 5.0)
   rack-cors
   rails (~> 6.1.7)

--- a/api/app/controllers/api/v1/pictures_controller.rb
+++ b/api/app/controllers/api/v1/pictures_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::PicturesController < ApplicationController
 
   def create
     picture = current_api_v1_user.pictures.build(picture_params)
-    if picture.save
+    if picture.save!
       render json: picture
     else
       # status400をすることでビューにどう表示するかを検討（エラーハンドリング）

--- a/api/app/controllers/api/v1/themes_controller.rb
+++ b/api/app/controllers/api/v1/themes_controller.rb
@@ -16,7 +16,8 @@ class Api::V1::ThemesController < ApplicationController
   end
 
   def show
-    render json: @theme.as_json
+    @pictures = @theme.pictures
+    render json: { theme: @theme.as_json, pictures: @pictures.as_json }
   end
 
   def destroy

--- a/api/app/models/picture.rb
+++ b/api/app/models/picture.rb
@@ -1,5 +1,4 @@
 class Picture < ApplicationRecord
-  mount_uploader :image, ImageUploader
   belongs_to :user
   belongs_to :theme
 

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -8,6 +8,7 @@ import SignIn from "./components/pages/SignIn";
 import SignUp from "./components/pages/SignUp";
 import Canvas from "./components/pages/Canvas";
 import ThemeIndex from "./components/pages/ThemeIndex";
+import Theme from "./components/pages/Theme";
 
 export const AuthContext = createContext();
 
@@ -71,6 +72,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/picture" element={<Canvas />} />
             <Route path="/themes" element={<ThemeIndex />} />
+            <Route path="/themes/:id" element={<Theme />} />
           </Routes>
         </CommonLayout>
       </Router>

--- a/front/src/components/atoms/cards/PictureCard.jsx
+++ b/front/src/components/atoms/cards/PictureCard.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { Picture } from "../picture/Picture";
+
+import Card from "@material-ui/core/Card";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  card: {
+    padding: theme.spacing(2),
+    maxWidth: 300,
+  }
+}))
+
+const PictureCard = (props) => {
+  const classes = useStyles();
+  
+  return (
+    <>
+      <Card
+        className={classes.card}
+      >
+        <Picture image={props.image} theme={props.theme} />
+      </Card>
+    </>
+  )
+}
+
+export default PictureCard;

--- a/front/src/components/atoms/picture/Picture.jsx
+++ b/front/src/components/atoms/picture/Picture.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles(() => ({
+  imageScales: {
+    maxWidth: '100%',
+    height: 'auto'
+  }
+}))
+
+
+export const Picture = (props) => {
+  let classes = useStyles();
+  let image_src = "data:image/png;base64," + props.image;
+
+  return (
+    <img src={image_src} alt={props.theme.name} className={classes.imageScales} />
+  )
+}

--- a/front/src/components/pages/Canvas.jsx
+++ b/front/src/components/pages/Canvas.jsx
@@ -131,9 +131,9 @@ const Canvas = () => {
         reader.readAsDataURL(blob);
 
         reader.onload = async (e) => {
-          e.preventDefault();
           let dataUrlBase64 = reader.result;
-          const base64 = dataUrlBase64.replace(/data:.*\/.*;base64,/, '');
+          let base64 = dataUrlBase64.replace(/data:.*\/.*;base64,/, '');
+          // console.log(base64);
           // paramsにしっかり値が入っていない！！（重要！）
           const params = generateParams(base64);
           console.log(params);
@@ -143,7 +143,6 @@ const Canvas = () => {
           try {
             const res = await createPicture(params);
             // 確認用コンソール出力です。実装できたら消してください。
-            console.log("ここだ！");
             if (res.status === 200) {
               // ページ遷移するようにする
               window.alert("登録されてるかもね。");

--- a/front/src/components/pages/Theme.jsx
+++ b/front/src/components/pages/Theme.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import PictureCard from "../atoms/cards/PictureCard";
+
+import { Grid } from "@material-ui/core";
+import { showTheme } from "../../lib/api/themes";
+
+
+const Theme = () => {
+  const { id } = useParams();
+  const [theme, setTheme] = useState("");
+  const [pictures, setPictures] = useState([]);
+  const handleShowTheme = async () => {
+    try {
+      // showTheme()にidを指定する必要がある。
+      const res = await showTheme(id);
+      if (res.status === 200) {
+        const data = res.data;
+        setTheme(data.theme);
+        setPictures(data.pictures);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  useEffect(() => {
+    handleShowTheme();
+  });
+
+  return (
+    <>
+      <Grid container spacing={3}>
+        {
+          pictures.map((picture) => (
+            <Grid item xs={4} key={picture.id}>
+              <PictureCard image={picture.image} theme={theme} />
+            </Grid>
+          ))
+        }
+      </Grid>
+    </>
+  )
+}
+
+export default Theme;

--- a/front/src/components/pages/ThemeIndex.jsx
+++ b/front/src/components/pages/ThemeIndex.jsx
@@ -1,16 +1,25 @@
 import React, { useState } from "react";
+import { Link } from 'react-router-dom';
 
 // import { RouteComponentProps, Link } from "react-router-dom";
 
 import Grid from "@material-ui/core/Grid";
 
+import { makeStyles } from "@material-ui/styles";
 import ThemeCard from "../atoms/cards/ThemeCard";
 import { getThemes } from "../../lib/api/themes";
 import { useEffect } from "react";
 
-const ThemeIndex = () => {
-  const [themes, setThemes] = useState([]);
+const useStyles = makeStyles((theme) => ({
+  link: {
+    textDecoration: "none"
+  }
+}));
 
+
+const ThemeIndex = () => {
+  const classes = useStyles();
+  const [themes, setThemes] = useState([]);
   const handleGetThemes = async () => {
     try {
       const res = await getThemes();
@@ -33,7 +42,16 @@ const ThemeIndex = () => {
         {
           themes.map((theme) => (
             <Grid item xs={4} key={theme.id}>
-              <ThemeCard title={theme.title} />
+              <Link to={{
+                pathname: "/themes/" + theme.id,
+                state: {id: theme.id}
+                
+              }}
+              id={theme.id}
+              className = {classes.link}
+              >
+                <ThemeCard title={theme.title} />
+              </Link>
             </Grid>
           ))
         }


### PR DESCRIPTION
### 概要
テーマ一覧画面と詳細画面をラフに作成した。
描いた絵がテーマに紐づいて管理されていることを確認。

### 課題
おそらくN＋1問題が発生している箇所があるので、追って対応すること！
絵画には描いたユーザー名が必要なのと、テーマ詳細画面にもテーマの名前を記載する必要がある。

### 次にやること
いいね機能の実装をやる！

### 関連するIssue
#9 
#19 
