### PR TITLE
User詳細画面の実装（ラフイメージ）

### DIFF
--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,19 @@
 class Api::V1::UsersController < ApplicationController
-  def index
-    render json: { message: "Hello World!" }
+  before_action :set_user, only: %i[show]
+
+  def show
+    render_json = ActiveModelSerializers::SerializableResource.new(
+      @user,
+      include: "**",
+      serializer: UserSerializer,
+      current_api_v1_user: current_api_v1_user,
+    ).as_json
+    render json: render_json
+  end
+
+  private
+  
+  def set_user
+    @user = User.find(params[:id])
   end
 end

--- a/api/app/serializers/theme_serializer.rb
+++ b/api/app/serializers/theme_serializer.rb
@@ -1,5 +1,5 @@
 class ThemeSerializer < ActiveModel::Serializer
-  attributes :id, :title, :created_at
+  attributes %i[id title created_at]
   has_many :pictures
 
   def initialize(object, **option)

--- a/api/app/serializers/user_serializer.rb
+++ b/api/app/serializers/user_serializer.rb
@@ -1,7 +1,12 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id
+  attributes :id, :name
+
   def initialize(object, **option)
     @current_api_v1_user = option[:current_api_v1_user]
     super
+  end
+
+  attribute :pictures do
+    object.pictures
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     namespace :v1 do
       # usersはまだindexしか用意していない。
-      resources :users, only: %i[index]
+      resources :users, only: %i[index show]
       resources :themes, only: %i[index create show destroy]
       # picturesはupdateを今後実装予定だが、一旦はパス
       resources :pictures, only: %i[index create show destroy]

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -10,6 +10,7 @@ import Canvas from "./components/pages/Canvas";
 import ThemeIndex from "./components/pages/ThemeIndex";
 import Theme from "./components/pages/Theme";
 import ShowPicture from "./components/pages/ShowPicture";
+import ShowUser from "./components/pages/ShowUser";
 
 export const AuthContext = createContext();
 
@@ -75,6 +76,7 @@ function App() {
             <Route path="/pictures/:id" element={<ShowPicture />} />
             <Route path="/themes" element={<ThemeIndex />} />
             <Route path="/themes/:id" element={<Theme />} />
+            <Route path="/users/:id" element={<ShowUser />} />
           </Routes>
         </CommonLayout>
       </Router>

--- a/front/src/components/layouts/Header.jsx
+++ b/front/src/components/layouts/Header.jsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme) => ({
 
 
 const Header = () => {
-  const { loading, isSignedIn, setIsSignedIn } = useContext(AuthContext);
+  const { loading, isSignedIn, setIsSignedIn, currentUser } = useContext(AuthContext);
   const classes = useStyles();
   const navigate = useNavigate();
 
@@ -62,6 +62,12 @@ const Header = () => {
       if (isSignedIn) {
         return (
           <>
+            <LinkButton
+              to={`/users/${currentUser?.id}`}
+              color={"inherit"}
+            >
+              プロフィール
+            </LinkButton>
             <LinkButton
               to={"/picture"}
               color={"inherit"}

--- a/front/src/components/pages/ShowUser.jsx
+++ b/front/src/components/pages/ShowUser.jsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from "react";
+import { showUser } from "../../lib/api/users";
+
+import { Grid } from "@material-ui/core";
+
+import PictureCard from "../atoms/cards/PictureCard";
+import { useParams } from "react-router-dom";
+
+const ShowUser = () => {
+  const { id } = useParams();
+  const [user, setUesr] = useState([]);
+  const [pictures, setPictures] = useState([]);
+
+  const handleShowUser = async () => {
+    try {
+      const res = await showUser(id);
+      if (res.status === 200) {
+        const data = res.data;
+        setUesr(data);
+        setPictures(data.pictures);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  useEffect(() => {
+    handleShowUser();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  
+  return (
+    <>
+      <h1>{user.name}さんの作品一覧</h1>
+      <Grid container spacing={3}>
+        {
+          pictures.map((picture) => (
+            <Grid item xs={4} key={picture.id}>
+              <PictureCard picture={picture} pictureId={picture.id} />
+            </Grid>
+          ))
+        }
+      </Grid>
+    </>
+  )
+};
+
+export default ShowUser;

--- a/front/src/lib/api/users.js
+++ b/front/src/lib/api/users.js
@@ -1,0 +1,10 @@
+import client from "./client";
+import Cookies from "js-cookie";
+
+export const showUser = (id) => {
+  return client.get(`/users/${id}`, { headers: {
+    "access-token": Cookies.get("_access_token"),
+    "client": Cookies.get("_client"),
+    "uid": Cookies.get("_uid"),
+    }});
+}


### PR DESCRIPTION
### 概要
ユーザーの詳細画面の実装をした。
・ユーザーごとに名前と紐づく絵画が表示される。
・ヘッダーのプロフィールLINKを押すと、ログインしているCurrentUser用のページに飛ぶよう設計
ただ、いいねができないので、次のPRではLikeコンポーネントを作成してそこでlikeStateとlikesのステートを管理する。

### 関連するIssue
#20

### 気づいたこと
フロント側だけど、DOMの構成を気にしないと画面上変なことになる。
例えば、同じコンポーネントを拾ってきていも、おそらくステートの管理方法がどこかでダブっていてステートをうまく保持できていないといった現象が起きた。
注意したほうが良さげ。

### 次の実装
Likeコンポーネントを作成すること。moleculesディレクトリを作成してそこで作業する。
基本的にLikeコンポーネント内でいいねに関するステートは管理するほうが良い。（今日中に対応すること。）