### PR TITLE
お絵描き機能の改善

### DIFF
--- a/api/app/controllers/api/v1/pictures_controller.rb
+++ b/api/app/controllers/api/v1/pictures_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::PicturesController < ApplicationController
 
   def index
     pictures = Picture.all.includes(:user, :theme)
-    render_json = ActiveModelSerializers::new(
+    render_json = ActiveModelSerializers::SerializableResource.new(
       pictures,
       includes: "**",
       each_serializer: PictureSerializer,
@@ -23,7 +23,7 @@ class Api::V1::PicturesController < ApplicationController
 
   def create
     picture = current_api_v1_user.pictures.build(picture_params)
-    if picture.save!
+    if picture.save
       render json: picture
     else
       # status400をすることでビューにどう表示するかを検討（エラーハンドリング）

--- a/api/app/serializers/picture_serializer.rb
+++ b/api/app/serializers/picture_serializer.rb
@@ -7,11 +7,15 @@ class PictureSerializer < ActiveModel::Serializer
   end
 
   attribute :liked do
-    @current_api_v1_user.like?(object)
+    if @current_api_v1_user
+      @current_api_v1_user.like?(object)
+    end
   end
 
   attribute :like_id do
-    object.likes.find_by(user_id: @current_api_v1_user.id)&.id
+    if @current_user_v1_user
+      object.likes.find_by(user_id: @current_api_v1_user.id)&.id
+    end
   end
 
   attribute :likes do

--- a/front/src/components/atoms/buttons/ResetButton.jsx
+++ b/front/src/components/atoms/buttons/ResetButton.jsx
@@ -20,6 +20,7 @@ export const ResetButton = (props) => {
         variant="contained"
         size="large"
         color="default"
+        fullWidth
         className={classes.submitBtn}
         onClick={props.resetCanvas}
       >

--- a/front/src/components/atoms/buttons/UploadButton.jsx
+++ b/front/src/components/atoms/buttons/UploadButton.jsx
@@ -20,6 +20,7 @@ export const UploadButton = (props) => {
         variant="contained"
         size="large"
         color="default"
+        fullWidth
         disabled={!props.theme ? true : false}
         className={classes.submitBtn}
         onClick={props.uploadCanvas}

--- a/front/src/components/atoms/selectBoxes/SelectBox.jsx
+++ b/front/src/components/atoms/selectBoxes/SelectBox.jsx
@@ -1,22 +1,22 @@
 import { FormControl, Select, InputLabel, MenuItem } from '@material-ui/core';
 
-export const SelectBox = (props) => {
+export const SelectBox = ({placeholder, option, options, setOption}) => {
   const onChange = (e) => {
-    props.setTheme(e.target.value);
+    setOption(e.target.value);
   }
   return (
     <>
       <FormControl fullWidth>
-        <InputLabel>テーマを選んでください</InputLabel>
+        <InputLabel>{placeholder}</InputLabel>
         <Select
           displayEmpty
           onChange={onChange}
-          value={props.theme || ''}
+          value={option || ''}
         >
           <MenuItem value="" disabled></MenuItem>
           {
-            props.themes.map((theme) => (
-              <MenuItem value={theme.id} key={theme.id}>{theme.title}</MenuItem>
+            options.map((opt) => (
+              <MenuItem value={opt} key={opt}>{opt.title}</MenuItem>
             ))
           }
         </Select>

--- a/front/src/components/layouts/Header.jsx
+++ b/front/src/components/layouts/Header.jsx
@@ -7,8 +7,8 @@ import { makeStyles } from "@material-ui/core/styles";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
-import IconButton from "@material-ui/core/IconButton";
-import MenuIcon from "@material-ui/icons/Menu";
+// import IconButton from "@material-ui/core/IconButton";
+// import MenuIcon from "@material-ui/icons/Menu";
 
 
 import { signOut } from "../../lib/api/auth";
@@ -111,13 +111,13 @@ const Header = () => {
     <>
       <AppBar position="static">
         <Toolbar>
-          <IconButton
+          {/* <IconButton
             edge="start"
             className={classes.iconButton}
             color="inherit"
           >
             <MenuIcon />
-          </IconButton>
+          </IconButton> */}
           <Typography
             component={Link}
             to="/"

--- a/front/src/components/pages/SignUp.jsx
+++ b/front/src/components/pages/SignUp.jsx
@@ -1,5 +1,5 @@
 // import Cookies from "js-cookie";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
 import { makeStyles } from "@material-ui/core/styles";
@@ -11,7 +11,7 @@ import Box from "@material-ui/core/Box";
 
 
 import { signUp } from "../../lib/api/auth";
-import { AuthContext } from "../../App";
+// import { AuthContext } from "../../App";
 import AlertMessage from "../utils/AlertMessage";
 import { SignUpButton } from "../atoms/buttons/SignUpButton";
 import { Form } from "../atoms/forms/Form";
@@ -43,7 +43,7 @@ const useStyles = makeStyles((theme) => ({
 const SignUp = () => {
   const classes = useStyles();
 
-  const { setIsSignedIn, setCurrentUser } = useContext(AuthContext);
+  // const { setIsSignedIn, setCurrentUser } = useContext(AuthContext);
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");

--- a/front/src/lib/api/pictures.js
+++ b/front/src/lib/api/pictures.js
@@ -2,7 +2,11 @@ import client from "./client";
 import Cookies from "js-cookie";
 
 export const getPictures = () => {
-  return client.get("/pictures");
+  return client.get("/pictures", { headers: {
+    "access-token": Cookies.get("_access_token"),
+    "client": Cookies.get("_client"),
+    "uid": Cookies.get("_uid"),
+  }});
 }
 
 export const createPicture = (params) => {


### PR DESCRIPTION
### 概要
Canvas画面に以下の項目を実装した。
- 配色変更のボタン
- 消しゴムモードの実装
- 線幅を変更するスライダーの実装

### 該当するIssue
#30 

### 改善できていない箇所
以下未対応なので、今後対応する

- 線幅を太くはできるが、細くできない問題
- セレクトボックスを触ると出る警告文の対応
- 各ぼたんやコンポーネントにいい感じのアイコンを当て込む。
アイコンはコンポーネント化して該当するIconを呼び出せるようにすること。

### 次の実装について
12月17日は以下の実装をします。
- ヘッダーからサイドバーに変更
- リロード待機中のアニメーションを実装（試行で）