### PR TITLE
絵の削除ボタンを作成

### DIFF
--- a/api/app/controllers/api/v1/pictures_controller.rb
+++ b/api/app/controllers/api/v1/pictures_controller.rb
@@ -32,11 +32,8 @@ class Api::V1::PicturesController < ApplicationController
   end
 
   def destroy
-    if @picture.destroy
-      render json: @picture
-    else
-      render json: { status: 400 }
-    end
+    @picture.destroy
+    render json: @picture
   end
 
   # プライベートメソッド

--- a/api/app/models/picture.rb
+++ b/api/app/models/picture.rb
@@ -2,7 +2,7 @@ class Picture < ApplicationRecord
   belongs_to :user
   belongs_to :theme
   # いいね機能
-  has_many :likes
+  has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
 
   validates :image, presence: true

--- a/api/app/models/theme.rb
+++ b/api/app/models/theme.rb
@@ -1,4 +1,4 @@
 class Theme < ApplicationRecord
-  has_many :pictures
+  has_many :pictures, dependent: :destroy
   validates :title, presence: true
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
-  has_many :pictures
+  has_many :pictures, dependent: :destroy
   has_many :likes
   has_many :liked_pictures, through: :likes, source: :picture
 

--- a/front/src/components/atoms/buttons/DeletePictureButton.jsx
+++ b/front/src/components/atoms/buttons/DeletePictureButton.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { makeStyles } from "@material-ui/core";
+import DeleteIcon from '@material-ui/icons/Delete';
+
+const useStyles = makeStyles(() => ({
+  deleteButton: {
+    cursor: "pointer",
+  },
+}))
+
+const DeletePicutreButton = ({pictureId, handleDeletePicture}) => {
+  const classes = useStyles();
+
+  return (
+    <DeleteIcon className={classes.deleteButton} onClick={handleDeletePicture} />
+  )
+};
+
+export default DeletePicutreButton;

--- a/front/src/components/atoms/buttons/DrawerCloseButton.jsx
+++ b/front/src/components/atoms/buttons/DrawerCloseButton.jsx
@@ -21,7 +21,7 @@ const DrawerCloseButton = ({handleDrawerClose}) => {
     <>
       <IconButton
         edge="start"
-        color="white"
+        color="inherit"
         onClick={handleDrawerClose}
         className={classes.menuButton}
       >

--- a/front/src/components/atoms/buttons/DrawerOpenButton.jsx
+++ b/front/src/components/atoms/buttons/DrawerOpenButton.jsx
@@ -21,7 +21,7 @@ const DrawerOpenButton = ({handleDrawerOpen}) => {
     <>
       <IconButton
         edge="start"
-        color="white"
+        color="inherit"
         aria-label="open drawer"
         onClick={handleDrawerOpen}
         className={classes.menuButton}

--- a/front/src/components/atoms/cards/PictureCard.jsx
+++ b/front/src/components/atoms/cards/PictureCard.jsx
@@ -4,7 +4,9 @@ import Picture from "../picture/Picture";
 import { Link } from "react-router-dom";
 
 import Likes from "../../molecules/Likes";
+import { deletePicture } from "../../../lib/api/pictures";
 
+import DeletePicutreButton from "../buttons/DeletePictureButton";
 import Card from "@material-ui/core/Card";
 import { makeStyles } from "@material-ui/core/styles";
 
@@ -16,8 +18,22 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-const PictureCard = ({picture, pictureId }) => {
+const PictureCard = ({picture, pictureId, pictures, setPictures}) => {
   const classes = useStyles();
+  const handleDeletePicture = async () => {
+    try {
+      const res = await deletePicture(pictureId);
+      if (res.status === 200) {
+        const newPictures = pictures.filter((picture) => {
+          return picture.id !== pictureId;
+        });
+        setPictures(newPictures);
+        window.alert('削除しました！');
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
 
   return (
     <>
@@ -37,6 +53,7 @@ const PictureCard = ({picture, pictureId }) => {
             />          
         </Link>
         <Likes picture={picture} pictureId={pictureId} />
+        <DeletePicutreButton pictureId={pictureId} handleDeletePicture={handleDeletePicture} />
       </Card>
     </>
   )

--- a/front/src/components/layouts/SideBar.jsx
+++ b/front/src/components/layouts/SideBar.jsx
@@ -23,6 +23,12 @@ const useStyles = makeStyles((theme) => ({
     padding: "0 8px",
     ...theme.mixins.toolbar,
   },
+  paper: {
+    padding: theme.spacing(2),
+    display: "flex",
+    overflow: "auto",
+    flexDirection: "column",
+  },
   drawerPaper: {
     position: "fixed",
     height: '100%',

--- a/front/src/components/pages/ShowPicture.jsx
+++ b/front/src/components/pages/ShowPicture.jsx
@@ -12,10 +12,15 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(2),
     maxWidth: 300,
     margin: 'auto'
-  }
+  },
+  animation: {
+    transition: '1s',
+    opacity: '1',
+  },
+  before: {
+    opacity: '0',
+  },
 }));
-
-
 
 const ShowPicture = () => {
   const classes = useStyles();
@@ -23,6 +28,7 @@ const ShowPicture = () => {
   const [picture, setPicture] = useState([]);
   const [likeState, setLikeState] = useState(false);
   const [likes, setLikes] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
   
   const handleShowPicture = async () => {
     try {
@@ -39,6 +45,8 @@ const ShowPicture = () => {
     }
   }
 
+  setTimeout(() => { setIsOpen(true) }, 200)
+
   const generateParams = () => {
     const likeParams = {
       picture_id: id,
@@ -53,37 +61,39 @@ const ShowPicture = () => {
 
   return (
     <>
-      <Grid container spacing={10}>
-        <Grid item xs={12}>
-        <Card
-            className={classes.card}
-          >
-            <Picture picture={picture} 
-              theme={picture.theme} 
-              image={picture.image}
-              />          
-            { likeState ? (
-              <UnLikeButton 
-                params={generateParams()} 
-                likeState={picture.liked}
-                setLikeState={setLikeState}
-                likeId={picture.like_id}
-                likes={likes}
-                setLikes={setLikes}
-              />
-            ) : (
-              <LikeButton 
-                params={generateParams()} 
-                likeState={picture.liked}
-                setLikeState={setLikeState}
-                likes={likes}
-                setLikes={setLikes}
-              />
-            )}
-          </Card>
-          <h1>アホ！！！！</h1>
+      <div className={isOpen ? classes.animation : classes.before}>
+        <Grid container spacing={10}>
+          <Grid item xs={12}>
+          <Card
+              className={classes.card}
+            >
+              <Picture picture={picture} 
+                theme={picture.theme} 
+                image={picture.image}
+                />          
+              { likeState ? (
+                <UnLikeButton 
+                  params={generateParams()} 
+                  likeState={picture.liked}
+                  setLikeState={setLikeState}
+                  likeId={picture.like_id}
+                  likes={likes}
+                  setLikes={setLikes}
+                />
+              ) : (
+                <LikeButton 
+                  params={generateParams()} 
+                  likeState={picture.liked}
+                  setLikeState={setLikeState}
+                  likes={likes}
+                  setLikes={setLikes}
+                />
+              )}
+            </Card>
+            <h1>アホ！！！！</h1>
+          </Grid>
         </Grid>
-      </Grid>
+      </div>
     </>
   )
 };

--- a/front/src/components/pages/ShowUser.jsx
+++ b/front/src/components/pages/ShowUser.jsx
@@ -1,15 +1,27 @@
 import React, { useState, useEffect } from "react";
 import { showUser } from "../../lib/api/users";
 
-import { Grid } from "@material-ui/core";
+import { Grid, makeStyles } from "@material-ui/core";
 
 import PictureCard from "../atoms/cards/PictureCard";
 import { useParams } from "react-router-dom";
 
+const useStyles = makeStyles((theme) => ({
+  animation: {
+    transition: '1s',
+    opacity: '1',
+  },
+  before: {
+    opacity: '0',
+  },
+}));
+
 const ShowUser = () => {
   const { id } = useParams();
+  const classes = useStyles();
   const [user, setUesr] = useState([]);
   const [pictures, setPictures] = useState([]);
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleShowUser = async () => {
     try {
@@ -24,6 +36,8 @@ const ShowUser = () => {
     }
   }
 
+  setTimeout(() => { setIsOpen(true) }, 300)
+
   useEffect(() => {
     handleShowUser();
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -32,16 +46,18 @@ const ShowUser = () => {
   
   return (
     <>
-      <h1>{user.name}さんの作品一覧</h1>
-      <Grid container spacing={3}>
-        {
-          pictures.map((picture) => (
-            <Grid item xs={4} key={picture.id}>
-              <PictureCard picture={picture} pictureId={picture.id} />
-            </Grid>
-          ))
-        }
-      </Grid>
+      <div className={isOpen ? classes.animation : classes.before}>
+        <h1>{user.name}さんの作品一覧</h1>
+        <Grid container spacing={3}>
+          {
+            pictures.map((picture) => (
+              <Grid item xs={4} key={picture.id}>
+                <PictureCard picture={picture} pictureId={picture.id} />
+              </Grid>
+            ))
+          }
+        </Grid>
+      </div>
     </>
   )
 };

--- a/front/src/components/pages/Theme.jsx
+++ b/front/src/components/pages/Theme.jsx
@@ -3,13 +3,25 @@ import React, { useState, useEffect } from "react";
 import PictureCard from "../atoms/cards/PictureCard";
 
 import { Grid } from "@material-ui/core";
-
 import { useParams } from "react-router-dom";
 import { showTheme } from "../../lib/api/themes";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles((theme) => ({
+  animation: {
+    transition: '1s',
+    opacity: '1',
+  },
+  before: {
+    opacity: '0',
+  }
+}));
 
 const Theme = () => {
+  const classes = useStyles();
   const { id } = useParams();
-  const [pictures, setPictures] = useState([]);
+  const [ pictures, setPictures ] = useState([]);
+  const [ isOpen, setIsOpen ] = useState(false);
   const handleShowTheme = async () => {
     try {
       const res = await showTheme(id);
@@ -21,6 +33,7 @@ const Theme = () => {
       console.log(e);
     }
   }
+  setTimeout(() => { setIsOpen(true) }, 100)
 
   useEffect(() => {
     handleShowTheme();
@@ -29,15 +42,22 @@ const Theme = () => {
 
   return (
     <>
-      <Grid container spacing={3}>
-        {
-          pictures.map((picture) => (
-            <Grid item xs={4} key={picture.id}>
-              <PictureCard picture={picture} pictureId={picture.id} />
-            </Grid>
-          ))
-        }
-      </Grid>
+      <div className={isOpen ? classes.animation : classes.before}>
+        <Grid container spacing={3}>
+          {
+            pictures.map((picture) => (
+              <Grid item xs={4} key={picture.id}>
+                <PictureCard
+                  picture={picture} 
+                  pictureId={picture.id}
+                  pictures={pictures}
+                  setPictures={setPictures}
+                />
+              </Grid>
+            ))
+          }
+        </Grid>
+      </div>
     </>
   )
 }

--- a/front/src/components/pages/ThemeIndex.jsx
+++ b/front/src/components/pages/ThemeIndex.jsx
@@ -11,12 +11,20 @@ import ThemeCard from "../atoms/cards/ThemeCard";
 const useStyles = makeStyles((theme) => ({
   link: {
     textDecoration: "none",
+  },
+  animation: {
+    transition: '1s',
+    opacity: '1',
+  },
+  before: {
+    opacity: '0',
   }
 }));
 
 
 const ThemeIndex = () => {
   const classes = useStyles();
+  const [isOpen, setIsOpen] = useState(false);
   const [themes, setThemes] = useState([]);
   const handleGetThemes = async () => {
     try {
@@ -34,25 +42,29 @@ const ThemeIndex = () => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  setTimeout(() => { setIsOpen(true) }, 100)
+
   return (
     <>
-      <Grid container spacing={3}>
-        {
-          themes.map((theme) => (
-            <Grid item xs={4} key={theme.id}>
-              <Link to={{
-                pathname: "/themes/" + theme.id,
-                state: {id: theme.id}
-              }}
-              id={theme.id}
-              className = {classes.link}
-              >
-                <ThemeCard theme={theme} title={theme.title} />
-              </Link>
-            </Grid>
-          ))
-        }
-      </Grid>
+      <div className={isOpen ? classes.animation : classes.before}>
+        <Grid container spacing={3}>
+          {
+            themes.map((theme) => (
+              <Grid item xs={4} key={theme.id}>
+                <Link to={{
+                  pathname: "/themes/" + theme.id,
+                  state: {id: theme.id}
+                }}
+                id={theme.id}
+                className = {classes.link}
+                >
+                  <ThemeCard theme={theme} title={theme.title} />
+                </Link>
+              </Grid>
+            ))
+          }
+        </Grid>
+      </div>
     </>
   )
 }

--- a/front/src/lib/api/pictures.js
+++ b/front/src/lib/api/pictures.js
@@ -15,10 +15,15 @@ export const createPicture = (params) => {
     "client": Cookies.get("_client"),
     "uid": Cookies.get("_uid"),
   }});
-}
+};
 
 export const deletePicture = (id) => {
-  return client.delete(`/picture/${id}`);
+  return client.delete(`/pictures/${id}`,
+  { headers: {
+    "access-token": Cookies.get("_access_token"),
+    "client": Cookies.get("_client"),
+    "uid": Cookies.get("_uid"),
+  }})
 }
 
 export const showPicture = (id) => {


### PR DESCRIPTION
### 概要
絵に対して削除ボタンを作成。
ボタンを押すとアラートが表示されて、動的に削除されるよう実装。
合わせて全体的にアニメーションを追加した。

### 該当するIssue
#34 

### 課題
CurrentUserのみの絵画しか削除できないようにする必要がある。（忘れた）
詳細ページ上には削除ボタンがない。今後削除したらプロフィールページに遷移するように実装する必要あり。

### 次の実装（12/20目途）
・額縁の設定
・各種ボタンのレイアウト整理