### PR TITLE
メタタグの修正

### DIFF
--- a/api/app/controllers/api/v1/pictures_controller.rb
+++ b/api/app/controllers/api/v1/pictures_controller.rb
@@ -16,6 +16,7 @@ class Api::V1::PicturesController < ApplicationController
   def show
     render_json = ActiveModelSerializers::SerializableResource.new(
       @picture,
+      includes: "**",
       serializer: PictureSerializer,
       current_api_v1_user: current_api_v1_user
     ).as_json

--- a/api/app/controllers/api/v1/themes_controller.rb
+++ b/api/app/controllers/api/v1/themes_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::ThemesController < ApplicationController
   def show
     render_json = ActiveModelSerializers::SerializableResource.new(
       @theme,
-      include: :pictures,
+      includes: "**",
       serializer: ThemeSerializer,
       current_api_v1_user: current_api_v1_user
     )

--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::UsersController < ApplicationController
   def show
     render_json = ActiveModelSerializers::SerializableResource.new(
       @user,
+      includes: "**",
       serializer: UserSerializer,
       current_api_v1_user: current_api_v1_user
     ).as_json

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="あなたの個性が光る、エモい絵を描くアプリです。"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,18 +24,14 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <!-- googleフォント用 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet">
     <title>画HACK</title>
-    <meta
-      name="description"
-      content="絵が苦手なあなたでも楽しく絵を描けるアプリです。"
-    />
     <!-- OGP設定メタタグ -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="画HACK" />
-    <meta property="og:description" content="あなたの個性が光る、エモい絵を描くアプリです。" />
     <meta property="og:url" content="https://gahack.netlify.app/" />
     <meta property="og:site_name" content="画HACK" />
     <meta property="og:locale" content="ja_JP" />


### PR DESCRIPTION
### 概要
OGP画像が表示されないので、metaタグを修正した。
おそらくS3に直接URLでアクセスしているのでアクセスがブロックされている可能性も大きい。
格納場所は要検討かもしれない。。

### 引き続き対応すること
・OGP画像の設定（Twitterシェア）
・管理画面の実装
・パスワードリセットのバグ（本番環境での確認）