### PR TITLE
Twitterシェア用画像のuploaderを調整

### DIFF
--- a/api/app/uploaders/image_uploader.rb
+++ b/api/app/uploaders/image_uploader.rb
@@ -52,5 +52,5 @@ class ImageUploader < CarrierWave::Uploader::Base
   #   "#{SecureRandom.uuid}.#{file.extension}" if original_filename
   # end
 
-  process resize_to_limit: [200, 200]
+  process resize_to_limit: [800, 418]
 end

--- a/api/app/uploaders/image_uploader.rb
+++ b/api/app/uploaders/image_uploader.rb
@@ -48,9 +48,9 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "#{SecureRandom.uuid}.#{file.extension}" if original_filename
-  end
+  # def filename
+  #   "#{SecureRandom.uuid}.#{file.extension}" if original_filename
+  # end
 
   process resize_to_limit: [200, 200]
 end

--- a/front/src/components/pages/Canvas.jsx
+++ b/front/src/components/pages/Canvas.jsx
@@ -61,7 +61,7 @@ const Canvas = () => {
   let eraser_x = 'white';
   let eraser_y = 12;
 
-  const generateParams = (base64, dataUrlBase64) => {
+  const generateParams = (base64) => {
     const pictureParams = {
       image: base64,
       theme_id: theme.id,

--- a/front/src/components/pages/ShowPicture.jsx
+++ b/front/src/components/pages/ShowPicture.jsx
@@ -141,7 +141,7 @@ const ShowPicture = () => {
               meta={[
                 { property: 'og:url', content: `https://gahack.netlify.app/pictures/${picture.id}` },
                 { name: 'twitter:card', content: 'summary_large_image' },
-                { name: 'twitter:image', content: picture.twitterCard.url },
+                { name: 'twitter:image', content: picture.twitterCard.url.to_s },
                 { name: 'twitter:title', content: '画HACK' },
                 { name: 'twitter:description', content: 'この絵のテーマはなんでしょう？' },
               ]}
@@ -171,7 +171,7 @@ const ShowPicture = () => {
                               <Tooltip title="Twitterシェア">
                                 <IconButton aria-label="twitter">
                                   <TwitterShareButton
-                                    url={`${process.env.REACT_APP_FRONT}/pictures/${picture.id}`}
+                                    url={`${process.env.REACT_APP_FRONT}/pictures/${picture.id}/twitter`}
                                     hashtags={["画HACK"]}
                                   >
                                     <ImTwitter />

--- a/front/src/components/pages/TwitterAnswer.jsx
+++ b/front/src/components/pages/TwitterAnswer.jsx
@@ -1,23 +1,30 @@
 import React, { useState, useEffect } from "react";
-import { makeStyles } from "@material-ui/core";
+import { makeStyles, Button, } from "@material-ui/core";
 import { showPicture } from '../../lib/api/pictures';
 import Picture from "../../components/atoms/picture/Picture";
 import Loader from "./Loader";
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 
 const useStyles = makeStyles((theme) => ({
   cardContent: {
     margin: '0 auto',
-    height: '300px',
+    height: '350px',
     width: '400px',
     textAlign: 'left'
   },
   picture: {
     position: 'relative',
-    top: '50%',
+    top: '70%',
     right: '0',
     fontSize: '8px',
   },
+  answer: {
+    fontSize: '30px',
+  },
+  link: {
+    color: 'white',
+    textDecoration: 'none',
+  }
 }));
 
 const TwitterAnswer = () => {
@@ -49,15 +56,24 @@ const TwitterAnswer = () => {
   return (
     <>
       {!loading ? (
-        <div className={classes.cardContent}>
-          <div className={classes.picture}>
-            <Picture 
-              picture={picture} 
-              theme={theme} 
-              image={picture.image}
-              />
+        <>
+          <div className={classes.cardContent}>
+            <div className={classes.picture}>
+              <Picture 
+                picture={picture} 
+                theme={theme} 
+                image={picture.image}
+                />
+            </div>
           </div>
-        </div>
+          <p className={classes.answer}>この絵のテーマは<strong>{theme.title}</strong>です！</p>
+          <p>お題に沿ってエモい絵描きましょう！</p>
+          <Button color="primary" variant="contained" >
+            <Link to="/" className={classes.link} >
+              トップ画面へ
+            </Link>
+          </Button>
+        </>
       ) : (
         <Loader />
       )}


### PR DESCRIPTION
### 概要
画像のurlとtwitter_cardカラムのurlが異なるというバグが発生していたため、修正。
ブランチ名とは異なるが、一旦プルリクして本番環境で調整する。