### PR TITLE
gtag追加、スクロールトップ機能の実装

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -32,13 +32,13 @@
     <!-- OGP設定メタタグ -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="画HACK" />
-    <meta property="og:url" content="https://gahack.netlify.app/" />
+    <meta property="og:url" content="%REACT_APP_FRONT%" />
     <meta property="og:site_name" content="画HACK" />
-    <meta property="og:image" content="https://gahack.netlify.app/TopImage.png" />
+    <meta property="og:image" content="%REACT_APP_FRONT%/TopImage.png" />
     <meta property="og:description" content="あなたの個性が光る、エモい絵を描くアプリです。" />
     <!-- twitterカード用 -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="https://gahack.netlify.app/TopImage.png" />
+    <meta name="twitter:image" content="%REACT_APP_FRONT%/TopImage.png" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -39,6 +39,20 @@
     <!-- twitterカード用 -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content="%REACT_APP_FRONT%/TopImage.png" />
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-F2CRE8NT4N"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      // ページビューの設定では以下の１行では不十分かも（追って修正）
+      gtag('config', 'G-F2CRE8NT4N')
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/front/src/components/pages/PrivacyPolicy.jsx
+++ b/front/src/components/pages/PrivacyPolicy.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Typography, Box, List, ListItem, Link, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
@@ -35,6 +35,14 @@ const useStyles = makeStyles((theme) => ({
 
 const PrivacyPolicy = () => {
   const classes = useStyles();
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  }, []);
+
   return (
     <>
       <div className={classes.container}>

--- a/front/src/components/pages/SignIn.jsx
+++ b/front/src/components/pages/SignIn.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import Cookies from "js-cookie";
 
@@ -59,6 +59,13 @@ export const SignIn = () => {
     };
     return signInParams;
   };
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  }, []);
 
   const handleSignInSubmit = async (e) => {
     e.preventDefault();

--- a/front/src/components/pages/SignUp.jsx
+++ b/front/src/components/pages/SignUp.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { makeStyles } from "@material-ui/core/styles";
@@ -82,6 +82,14 @@ const SignUp = () => {
       setAlertMessageOpen(true);
     }
   };
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  }, []);
+  
   return (
     <>
      <div className={classes.container}>

--- a/front/src/components/pages/TermsOfService.jsx
+++ b/front/src/components/pages/TermsOfService.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Typography, Box, List, ListItem, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
@@ -34,6 +34,13 @@ const useStyles = makeStyles((theme) => ({
 
 const TermsOfService = () => {
   const classes = useStyles();
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  }, []);
+
   return (
     <>
       <div className={classes.container} >

--- a/front/src/components/pages/TopPage.jsx
+++ b/front/src/components/pages/TopPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AuthContext } from "../../App";
 import TopMain from '../organisms/TopMain';
@@ -26,6 +26,13 @@ const TopPage = () => {
   const { isSignedIn, currentUser } = useContext(AuthContext);
 
   setTimeout(() => { setIsOpen(true) }, 200);
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
### 概要

- index.htmlに記載するfrontのURLを環境変数で記載。
- gtagを追加した。ただ、ページビューの設定はSPAなのでうまく行っていないと思われる。
以下の記事で修正することも要検討。
https://qiita.com/mildsummer/items/184315e6f9a6d298113e
- ページ遷移した時に縦に長いページは上にスクロールするよう機能実装した。

### 次の実装
- レスポンシブデザイン
- Twitterシェア問題ないか確認
- ページネーションのブラウザバック対応