### PR TITLE
画像の参照先をS3に変更

### DIFF
--- a/api/app/controllers/api/v1/pictures_controller.rb
+++ b/api/app/controllers/api/v1/pictures_controller.rb
@@ -51,7 +51,8 @@ class Api::V1::PicturesController < ApiController
 
   # TOP5の絵をランキング形式で表示
   def best_pictures
-    @pictures = Picture.includes({ user: [:followings, :followers] }, :theme, :liked_users, :likes, :comments).recent.best_pictures
+    @pictures = Picture.includes({ user: [:likes, :liked_pictures, :comments, :bookmarks, :bookmark_pictures, :followings, :followers] },
+                                  :theme, :liked_users, :likes, :comments, :bookmarks).recent.best_pictures
     render_json = ActiveModelSerializers::SerializableResource.new(
       @pictures,
       includes: "**",

--- a/api/app/serializers/picture_serializer.rb
+++ b/api/app/serializers/picture_serializer.rb
@@ -1,5 +1,5 @@
 class PictureSerializer < ActiveModel::Serializer
-  attributes %i[id image twitter_card frame_id created_at]
+  attributes %i[id twitter_card frame_id created_at]
 
   has_many :comments, serializer: CommentSerializer do
     object.comments.recent

--- a/api/app/serializers/theme_serializer.rb
+++ b/api/app/serializers/theme_serializer.rb
@@ -1,5 +1,5 @@
 class ThemeSerializer < ActiveModel::Serializer
-  attributes %i[id title created_at]
+  attributes %i[id title]
   has_many :pictures, serializer: PictureSerializer do
     object.pictures.recent
   end

--- a/front/src/components/atoms/picture/Picture.jsx
+++ b/front/src/components/atoms/picture/Picture.jsx
@@ -11,13 +11,12 @@ const useStyles = makeStyles(() => ({
 }))
 
 
-const Picture = memo(({theme, picture, image}) => {
+const Picture = memo(({theme, picture }) => {
   const classes = useStyles();
-  const image_src = "data:image/png;base64," + image;
   return (
     <>
       <div className={picture.frameId === 2 ? `${styles.second}` : `${styles.first}`}>
-        <img src={image_src} alt={theme} className={classes.imageScales} />
+        <img src={picture.twitterCard.url} alt={theme} className={classes.imageScales} />
       </div>
     </>
   )

--- a/front/src/components/pages/Timeline.jsx
+++ b/front/src/components/pages/Timeline.jsx
@@ -80,7 +80,6 @@ const Timeline = () => {
   useEffect(() => {
     handleGetPictures();
   }, [handleGetPictures, page]);
-  console.log('render');
 
   return (
     <>


### PR DESCRIPTION
### 概要
レスポンスの原因として遅い原因として画像のアップロードに時間がかかっていることだと考えた。
そのため、カラムのバイナリデータを読み込むのではなく、参照先をS3に変えた。
[![Image from Gyazo](https://i.gyazo.com/f035a4cb25de09ec6a30d218b55aa061.png)](https://gyazo.com/f035a4cb25de09ec6a30d218b55aa061)

それに加えて、シリアライザーからimageカラムを除き、失念していたN＋1を対応した。
一旦これでパフォーマンスを想定してみる。